### PR TITLE
Version and name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,6 @@
     "@typescript-eslint/no-floating-promises": "warn",
     "prettier/prettier": "warn",
     "no-console": "off",
-    "import/extensions": "off",
     "no-unused-vars": "off",
     "github/array-foreach": "off",
     "i18n-text/no-en": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/no-floating-promises": "warn",
     "prettier/prettier": "warn",
     "no-console": "off",
+    "import/extensions": "off",
     "no-unused-vars": "off",
     "github/array-foreach": "off",
     "i18n-text/no-en": "off",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 notes.txt
 dist/
+src/version.ts
 node_modules/
 .idea

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ See [API documentation](https://octomind.dev/docs/api-reference/)
 
 ## Usage
 
-1. Install the package - `npm i -g @octomind/cli` and use it directly e.g. `@octomind/cli -h`
-2. Use the cli through npx e.g. `npx @octomind/cli -h`
+1. Install the package - `npm i -g @octomind/octomind` and use it directly e.g. `octomind -h`
+2. Use the cli through npx e.g. `npx @octomind/octomind -h`
 
 ## Commands
 
@@ -18,7 +18,7 @@ See [API documentation](https://octomind.dev/docs/api-reference/)
 Run test cases against a specified URL.
 
 ```bash
-npx @octomind/cli execute \
+octomind execute \
   --api-key <key> \
   --test-target-id <id> \
   --url <url> \
@@ -46,7 +46,7 @@ Options:
 Retrieve details about a specific test report.
 
 ```bash
-npx @octomind/cli  report \
+octomind report \
   --api-key <key> \
   --test-target-id <id> \
   --report-id <id> \
@@ -103,7 +103,7 @@ Example JSON output:
 Register a new private location worker. If you use the [private location worker](https://github.com/OctoMind-dev/private-location-worker) it will register itself on startup automatically.
 
 ```bash
-npx @octomind/cli register-location \
+octomind register-location \
   --api-key <key> \
   --name <name> \
   --proxypass <password> \
@@ -125,7 +125,7 @@ Options:
 Remove a registered private location worker. If you use the [private location worker](https://github.com/OctoMind-dev/private-location-worker) it will unregister itself when going offline automatically.
 
 ```bash
-npx @octomind/cli unregister-location \
+octomind unregister-location \
   --api-key <key> \
   --name <name> \
   [--json]
@@ -141,7 +141,7 @@ Options:
 List all registered private locations.
 
 ```bash
-npx @octomind/cli list-private-locations \
+octomind list-private-locations \
   --api-key <key> \
   [--json]
 ```
@@ -166,7 +166,7 @@ Private Locations:
 List all available environments.
 
 ```bash
-npx @octomind/cli list-environments \
+octomind list-environments \
   --api-key <key> \
   --test-target-id <id> \
   [--json]
@@ -182,7 +182,7 @@ Options:
 Create a new environment for a test target.
 
 ```bash
-npx @octomind/cli create-environment \
+octomind create-environment \
   --api-key <key> \
   --test-target-id <id> \
   --name <name> \
@@ -216,7 +216,7 @@ Options:
 Update an existing environment.
 
 ```bash
-npx @octomind/cli update-environment \
+octomind update-environment \
   --api-key <key> \
   --test-target-id <id> \
   --environment-id <id> \
@@ -252,7 +252,7 @@ Options:
 Delete an existing environment.
 
 ```bash
-npx @octomind/cli delete-environment \
+octomind delete-environment \
   --api-key <key> \
   --test-target-id <id> \
   --environment-id <id> \

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "octomind": "./dist/index.js"
   },
   "scripts": {
-    "lint": "npx genversion -e src/version.ts && eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
-    "build": "npx genversion -e src/version.ts && tsc --project tsconfig.build.json",
+    "lint": "npx genversion -d -e src/version.ts && eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
+    "build": "npx genversion -d -e src/version.ts && tsc --project tsconfig.build.json",
     "octomind": "tsx src/cli.ts",
-    "test": "npx genversion -e src/version.ts && jest",
+    "test": "npx genversion -d -e src/version.ts && jest",
     "test:watch": "npx genversion -e src/version.ts && jest --watch"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
-    "build": "tsc --project tsconfig.build.json",
+    "build": "npx genversion -e src/version.ts && tsc --project tsconfig.build.json",
     "octomind-cli": "tsx src/cli.ts",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octomind/octomind",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "a command line client for octomind apis",
   "main": "./dist/index.js",
   "packageManager": "pnpm@9.15.6+sha512.139cab068fdf0b751268179ac5f909b5be72afb4a75c513d1905d151befc8977b593d3cf8671ed83d4d6637c5c94b98ffbce108125de4a5a27a31233601a99de",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "octomind": "./dist/index.js"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
+    "lint": "npx genversion -e src/version.ts && eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
     "build": "npx genversion -e src/version.ts && tsc --project tsconfig.build.json",
-    "octomind-cli": "tsx src/cli.ts",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "octomind": "tsx src/cli.ts",
+    "test": "npx genversion -e src/version.ts && jest",
+    "test:watch": "npx genversion -e src/version.ts && jest --watch"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "octomind": "./dist/index.js"
   },
   "scripts": {
-    "lint": "npx genversion -d -e src/version.ts && eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
-    "build": "npx genversion -d -e src/version.ts && tsc --project tsconfig.build.json",
+    "lint": "npx genversion -des src/version.ts && eslint src/**/*.ts tests/**/*.ts --max-warnings=0",
+    "build": "npx genversion -des src/version.ts && tsc --project tsconfig.build.json",
     "octomind": "tsx src/cli.ts",
-    "test": "npx genversion -d -e src/version.ts && jest",
+    "test": "npx genversion -des src/version.ts && jest",
     "test:watch": "npx genversion -e src/version.ts && jest --watch"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@octomind/cli",
-  "version": "1.0.2",
+  "name": "@octomind/octomind",
+  "version": "1.0.3",
   "description": "a command line client for octomind apis",
   "main": "./dist/index.js",
   "packageManager": "pnpm@9.15.6+sha512.139cab068fdf0b751268179ac5f909b5be72afb4a75c513d1905d151befc8977b593d3cf8671ed83d4d6637c5c94b98ffbce108125de4a5a27a31233601a99de",
@@ -8,7 +8,7 @@
     "node": ">=20.0.0"
   },
   "bin": {
-    "cli": "./dist/index.js"
+    "octomind": "./dist/index.js"
   },
   "scripts": {
     "lint": "eslint src/**/*.ts tests/**/*.ts --max-warnings=0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,8 +74,9 @@ export const executeTests = async (
     },
     environmentName: options.environment,
     tags: options.tags,
+    variablesToOverwrite: options.variablesToOverwrite
   };
-
+  
   const response = await apiCall<TestReportResponse>(
     "post",
     "/apiKey/v2/execute",

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,9 +74,9 @@ export const executeTests = async (
     },
     environmentName: options.environment,
     tags: options.tags,
-    variablesToOverwrite: options.variablesToOverwrite
+    variablesToOverwrite: options.variablesToOverwrite,
   };
-  
+
   const response = await apiCall<TestReportResponse>(
     "post",
     "/apiKey/v2/execute",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { program, Option, Command } from "commander";
+import { version } from "../package.json";
 import {
   createEnvironment,
   deleteEnvironment,
@@ -33,7 +34,8 @@ export const buildCmd = (): Command => {
     .name("octomind-cli")
     .description(
       "Octomind CLI tool. see https://octomind.dev/docs/api-reference/",
-    );
+    )
+    .version(version);
 
   createCommandWithCommonOptions("execute")
     .description("Execute test cases")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { program, Option, Command } from "commander";
-import { version } from "../package.json";
+import { version } from "./version";
 import {
   createEnvironment,
   deleteEnvironment,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ export const buildCmd = (): Command => {
   program
     .name("octomind-cli")
     .description(
-      "Octomind CLI tool. see https://octomind.dev/docs/api-reference/",
+      `Octomind CLI tool. Version: ${version}. see https://octomind.dev/docs/api-reference/`,
     )
     .version(version);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDir": ".",
     "strict": true,
     "noImplicitAny": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
before publish a new version, I would like to rename because when you did `npm i -g @octomind/cli`, subsequent calls where just `cli something` instead of `octomind execute -k .... `.

So the name of the executable should be octomind not cli